### PR TITLE
Fix missing eigenvalue difference calculation

### DIFF
--- a/nonrad/elphon.py
+++ b/nonrad/elphon.py
@@ -286,9 +286,10 @@ def get_Wif_from_WSWQ(
 
     # first compute the eigenvalue differences
     bvr = BSVasprun(initial_vasprun)
+    sp = Spin.up if spin == 0 else Spin.down
+    def_eig = bvr.eigenvalues[sp][kpoint-1][def_index-1][0]
     for i, bi in enumerate(bulk_index):
-        sp = Spin.up if spin == 0 else Spin.down
-        deig[i] = bvr.eigenvalues[sp][kpoint-1][bi-1][0]
+        deig[i] = bvr.eigenvalues[sp][kpoint-1][bi-1][0] - def_eig
     deig = np.abs(deig)
 
     # now compute for each Q


### PR DESCRIPTION
Hi Mark,
Thanks for creating a great code! 

At present, `deig` actually corresponds to the bulk_index eigenvalues, rather than the difference in eigenvalues between the bulk and defect.
Tested and seems to work as expected. (I noticed this from sanity testing with a manual calculation of Wif using the WSWQ, dQ and eigenvalues, which was giving me different results at first, but this fixed it).

Demonstration:
<img width="1090" alt="image" src="https://user-images.githubusercontent.com/51478689/101797000-73477100-3b01-11eb-8df2-d8ae385243e5.png">
<img width="1110" alt="image" src="https://user-images.githubusercontent.com/51478689/101797031-7b071580-3b01-11eb-8912-ab55783e3247.png">
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/51478689/101797067-82c6ba00-3b01-11eb-9114-199862f7b167.png">
<img width="1093" alt="image" src="https://user-images.githubusercontent.com/51478689/101797087-88240480-3b01-11eb-9f8f-c7965daee941.png">
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/51478689/101797110-9114d600-3b01-11eb-989c-372367652164.png">
<img width="989" alt="image" src="https://user-images.githubusercontent.com/51478689/101797172-a0941f00-3b01-11eb-8b5b-b1e68eddef5a.png">


PS: I saw your talk at MRS btw, very interesting work!